### PR TITLE
Docs: add current status note for demo integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ Finding optimal NHL 26 HUT line combinations using Answer Set Programming (ASP) 
 
 ---
 
+## ✅ Current Status (for demo work)
+
+- Goal 1 Stage B “grounding/enumeration” is being prepared for merge into `dev` (see `docs/GOAL_1.md` for the pipeline description).
+- If you are integrating backend/frontend now: align first on the expected input facts and outputs described in `docs/ASP_INTEGRATION.md`.
+
 ## 🎯 Project Goal
 
 This project focuses on **finding the best NHL 26 HUT line combinations** under user constraints, using **Answer Set Programming (ASP) with Clingo**.  


### PR DESCRIPTION
Summary
Adds a short “Current Status (for demo work)” note in README.md to help integration/demo coordination.
Tests
venv/bin/python -m pytest -q (97 passed)