### PR TITLE
Demo: add endpoint to serve Goal 1 Stage B artifacts

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -24,7 +24,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from .routes import players, combos, optimize, stats, best
+from .routes import players, combos, optimize, stats, best, demo
 from ..core.data import get_data_loader
 
 
@@ -114,6 +114,7 @@ app.include_router(combos.router, prefix="/combos", tags=["Line Combinations"])
 app.include_router(optimize.router, prefix="/optimize", tags=["Optimization"])
 app.include_router(stats.router, prefix="/stats", tags=["Statistics"])
 app.include_router(best.router, prefix="/best", tags=["Best Lines (Goal 1)"])
+app.include_router(demo.router, prefix="/demo", tags=["Demo"])
 
 
 # =============================================================================
@@ -155,4 +156,3 @@ async def health_check():
         return {"status": "healthy", "data": "loaded"}
     except Exception as e:
         return {"status": "unhealthy", "error": str(e)}
-

--- a/src/api/routes/demo.py
+++ b/src/api/routes/demo.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Literal
+
+from fastapi import APIRouter, HTTPException
+
+
+router = APIRouter()
+
+
+@router.get("/goal1-stageb", summary="Return Goal 1 Stage B demo JSON artifact")
+async def get_goal1_stageb_demo(pos: Literal["fwd", "def"] = "fwd"):
+    """
+    Serves locally-generated demo artifacts written by `scripts/demo_goal1_stageb.py`.
+
+    This endpoint is intentionally simple for demos: it does not execute the solver.
+    """
+    repo_root = Path(__file__).resolve().parents[3]
+    filename = "demo_goal1_stageb_fwd.json" if pos == "fwd" else "demo_goal1_stageb_def.json"
+    path = repo_root / "out" / filename
+
+    if not path.exists():
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                f"Demo artifact not found: {path}. Generate it with "
+                "`venv/bin/python scripts/demo_goal1_stageb.py`."
+            ),
+        )
+
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        raise HTTPException(status_code=500, detail=f"Invalid JSON in demo artifact: {e}") from e
+

--- a/tests/test_demo_endpoint.py
+++ b/tests/test_demo_endpoint.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.api.main import app
+
+
+client = TestClient(app)
+
+
+@pytest.fixture
+def demo_out_dir() -> Path:
+    return Path(__file__).resolve().parents[1] / "out"
+
+
+def _backup_if_exists(path: Path) -> Path | None:
+    if not path.exists():
+        return None
+    backup = path.with_suffix(path.suffix + ".bak_test")
+    path.replace(backup)
+    return backup
+
+
+def _restore_backup(backup: Path | None, target: Path) -> None:
+    if backup is None:
+        return
+    if target.exists():
+        target.unlink()
+    backup.replace(target)
+
+
+def test_demo_goal1_stageb_returns_json_when_artifact_exists(demo_out_dir: Path):
+    demo_out_dir.mkdir(parents=True, exist_ok=True)
+    artifact = demo_out_dir / "demo_goal1_stageb_fwd.json"
+    backup = _backup_if_exists(artifact)
+
+    try:
+        payload = {"schema_version": 1, "pos": "fwd", "combo_ids": [22], "count": 0, "solutions": []}
+        artifact.write_text(json.dumps(payload), encoding="utf-8")
+
+        response = client.get("/demo/goal1-stageb?pos=fwd")
+        assert response.status_code == 200
+        assert response.json()["schema_version"] == 1
+        assert response.json()["pos"] == "fwd"
+    finally:
+        if artifact.exists():
+            artifact.unlink()
+        _restore_backup(backup, artifact)
+
+
+def test_demo_goal1_stageb_404_when_missing(demo_out_dir: Path):
+    demo_out_dir.mkdir(parents=True, exist_ok=True)
+    artifact = demo_out_dir / "demo_goal1_stageb_def.json"
+    backup = _backup_if_exists(artifact)
+
+    try:
+        if artifact.exists():
+            artifact.unlink()
+        response = client.get("/demo/goal1-stageb?pos=def")
+        assert response.status_code == 404
+    finally:
+        _restore_backup(backup, artifact)
+


### PR DESCRIPTION
**Summary**
Adds GET /demo/goal1-stageb?pos=fwd|def to serve locally-generated Stage B demo JSON artifacts from out/.
Does not run the solver in-request; this is intentionally for demo/UI integration.
How to use

Generate artifacts: venv/bin/python scripts/demo_goal1_stageb.py
Run API: venv/bin/python -m uvicorn src.api.main:app --reload --port 8000
Fetch: curl -sS "http://127.0.0.1:8000/demo/goal1-stageb?pos=fwd"

**Tests**

**venv/bin/python -m pytest -q (99 passed)**