### PR TITLE
Goal 2: brute-force solver for optimize endpoints (demo unblocker)

### DIFF
--- a/src/api/routes/optimize.py
+++ b/src/api/routes/optimize.py
@@ -608,11 +608,18 @@ async def get_solver_status():
     Returns information about the solver implementation status.
     Useful for frontend to know which features are available.
     """
-    # Check if real solver is implemented
+    solver_class = solver.__class__.__name__
     is_placeholder = isinstance(solver, PlaceholderSolver)
+    is_goal2_bruteforce = solver_class == "Goal2BruteForceSolver"
     
     return {
-        "solver_type": "placeholder" if is_placeholder else "clingo",
+        "solver_type": (
+            "placeholder"
+            if is_placeholder
+            else "goal2_bruteforce"
+            if is_goal2_bruteforce
+            else "clingo"
+        ),
         "features": {
             "forward_line": True,
             "defense_pair": True,
@@ -622,6 +629,8 @@ async def get_solver_status():
         "message": (
             "Using placeholder solver. ASP team: implement src/asp/solver.py"
             if is_placeholder
+            else "Using brute-force demo solver (Goal 2)."
+            if is_goal2_bruteforce
             else "Clingo ASP solver active"
         ),
     }

--- a/src/api/routes/optimize.py
+++ b/src/api/routes/optimize.py
@@ -38,6 +38,12 @@ from ...core.models import (
     RewardType,
 )
 
+# Optional (non-ASP) demo solver for Goal 2, used to unblock interactive demo work.
+try:
+    from ...asp.goal2_bruteforce import Goal2BruteForceSolver
+except Exception:  # pragma: no cover
+    Goal2BruteForceSolver = None  # type: ignore
+
 # ASP Solver import - to be implemented by ASP team
 # from ...asp.solver import ASPSolver
 
@@ -396,7 +402,10 @@ class PlaceholderSolver(ASPSolverInterface):
 
 # Use placeholder for now - replace with real solver when ASP team implements it
 # solver = ASPSolver()  # Real implementation
-solver = PlaceholderSolver()  # Placeholder
+if Goal2BruteForceSolver is not None:
+    solver = Goal2BruteForceSolver()
+else:
+    solver = PlaceholderSolver()  # Placeholder
 
 
 # =============================================================================
@@ -608,4 +617,3 @@ async def get_solver_status():
             else "Clingo ASP solver active"
         ),
     }
-

--- a/src/api/routes/optimize.py
+++ b/src/api/routes/optimize.py
@@ -458,12 +458,16 @@ async def optimize_forward_line(request: OptimizationRequest):
         
         elapsed_ms = int((time.time() - start_time) * 1000)
         
+        candidates_evaluated = getattr(solver, "last_combinations_evaluated", 0)
+        if not candidates_evaluated:
+            candidates_evaluated = getattr(solver, "last_candidates_evaluated", 0)
+
         return OptimizationResponse(
             success=True,
             message=f"Found {len(solutions)} solution(s)",
             solutions=solutions,
             computation_time_ms=elapsed_ms,
-            candidates_evaluated=0,  # ASP solver will provide this
+            candidates_evaluated=int(candidates_evaluated),
         )
     
     except NotImplementedError as e:
@@ -496,12 +500,16 @@ async def optimize_defense_pair(request: OptimizationRequest):
         
         elapsed_ms = int((time.time() - start_time) * 1000)
         
+        candidates_evaluated = getattr(solver, "last_combinations_evaluated", 0)
+        if not candidates_evaluated:
+            candidates_evaluated = getattr(solver, "last_candidates_evaluated", 0)
+
         return OptimizationResponse(
             success=True,
             message=f"Found {len(solutions)} solution(s)",
             solutions=solutions,
             computation_time_ms=elapsed_ms,
-            candidates_evaluated=0,
+            candidates_evaluated=int(candidates_evaluated),
         )
     
     except NotImplementedError as e:

--- a/src/asp/goal2_bruteforce.py
+++ b/src/asp/goal2_bruteforce.py
@@ -54,6 +54,7 @@ class Goal2BruteForceSolver:
     def __init__(self, *, data_dir: str = "data/") -> None:
         self.loader = get_data_loader(data_dir)
         self.last_candidates_evaluated = 0
+        self.last_combinations_evaluated = 0
 
     def optimize_forward_line(
         self,
@@ -73,9 +74,6 @@ class Goal2BruteForceSolver:
             excluded_ids=constraints.excluded_player_ids,
         )
 
-        if constraints.require_center:
-            forwards = [p for p in forwards if str(getattr(p, "position", "")).upper() == "C"]
-
         forwards = _dedupe_best_card_per_player(forwards)
         forwards = _cap_candidates(forwards, target=target, limit=60)
 
@@ -88,6 +86,7 @@ class Goal2BruteForceSolver:
             k=num_solutions,
         )
         self.last_candidates_evaluated = len(forwards)
+        self.last_combinations_evaluated = _n_choose_k(len(forwards), 3)
         return [s.solution for s in scored]
 
     def optimize_defense_pair(
@@ -119,6 +118,7 @@ class Goal2BruteForceSolver:
             k=num_solutions,
         )
         self.last_candidates_evaluated = len(defense)
+        self.last_combinations_evaluated = _n_choose_k(len(defense), 2)
         return [s.solution for s in scored]
 
     def optimize_full_team(
@@ -152,6 +152,20 @@ def _cap_candidates(players: list, *, target: OptimizationTarget, limit: int) ->
     else:
         players.sort(key=lambda p: (-int(getattr(p, "overall", 0)), float(getattr(p, "salary", 0.0))))
     return players[:limit]
+
+def _n_choose_k(n: int, k: int) -> int:
+    if k < 0 or n < 0 or k > n:
+        return 0
+    if k == 0:
+        return 1
+    if k == 1:
+        return n
+    if k == 2:
+        return (n * (n - 1)) // 2
+    if k == 3:
+        return (n * (n - 1) * (n - 2)) // 6
+    # Not needed for this module.
+    raise ValueError("Unsupported k")
 
 
 def _score_key_for_target(
@@ -188,6 +202,10 @@ def _score_lines(
         pids = [int(getattr(p, "player_id", getattr(p, "id"))) for p in combo_players]
         if len(set(pids)) != len(pids):
             continue
+
+        if position == Position.FORWARD and constraints.require_center:
+            if not any(str(getattr(p, "position", "")).upper() == "C" for p in combo_players):
+                continue
 
         active: list[ActiveCombo] = []
         ovr_bonus = 0
@@ -269,4 +287,3 @@ def _score_lines(
     for i, s in enumerate(out, start=1):
         s.solution.rank = i
     return out
-

--- a/src/asp/goal2_bruteforce.py
+++ b/src/asp/goal2_bruteforce.py
@@ -130,8 +130,93 @@ class Goal2BruteForceSolver:
         raise NotImplementedError("Full-team optimization is not implemented in the brute-force demo solver.")
 
     def validate_line(self, player_ids: list[int], position_type: str) -> dict:
-        # Reuse the existing logic from the optimize routes placeholder (kept there for now).
-        raise NotImplementedError("Use the /optimize/validate endpoint placeholder for now.")
+        position_type = position_type.lower().strip()
+        if position_type == "forward":
+            candidates = self.loader.get_forwards()
+            combos = self.loader.get_forward_combos()
+            expected_count = 3
+        elif position_type == "defense":
+            candidates = self.loader.get_defense()
+            combos = self.loader.get_defense_combos()
+            expected_count = 2
+        else:
+            return {"valid": False, "error": "position_type must be 'forward' or 'defense'"}
+
+        if len(player_ids) != expected_count:
+            return {"valid": False, "error": f"Expected {expected_count} players, got {len(player_ids)}"}
+
+        # Allow lookup by either card id or player_id; prefer best overall card.
+        player_map: dict[str, object] = {}
+        for p in candidates:
+            keys = [str(getattr(p, "id"))]
+            pid = getattr(p, "player_id", None)
+            if pid is not None:
+                keys.append(str(pid))
+            for key in keys:
+                existing = player_map.get(key)
+                if existing is None or int(getattr(p, "overall", 0)) > int(getattr(existing, "overall", 0)):
+                    player_map[key] = p
+
+        selected: list[object] = []
+        for pid in player_ids:
+            key = str(pid)
+            if key not in player_map:
+                return {"valid": False, "error": f"Player ID not found: {pid}"}
+            selected.append(player_map[key])
+
+        active: list[dict] = []
+        ovr_bonus = 0
+        sal_bonus = 0
+        ap_bonus = 0
+        for combo in combos:
+            if not combo_activates(selected, combo):
+                continue
+            active.append(
+                {
+                    "id": int(combo.id),
+                    "reward_type": combo.reward_type.value,
+                    "reward_amount": int(combo.reward_amount),
+                    "description": _combo_description(combo.get_conditions()),
+                }
+            )
+            if combo.reward_type == RewardType.OVR:
+                ovr_bonus += int(combo.reward_amount)
+            elif combo.reward_type == RewardType.SAL:
+                sal_bonus += int(combo.reward_amount)
+            elif combo.reward_type == RewardType.AP:
+                ap_bonus += int(combo.reward_amount)
+
+        total_ovr = sum(int(getattr(p, "overall", 0)) for p in selected)
+        base_salary = sum(float(getattr(p, "salary", 0.0)) for p in selected)
+        base_ap = 0
+
+        return {
+            "valid": True,
+            "players": [
+                {
+                    "id": int(getattr(p, "id")),
+                    "player_id": int(getattr(p, "player_id", getattr(p, "id"))),
+                    "name": f"{getattr(p, 'first_name', '')} {getattr(p, 'last_name', '')}".strip(),
+                    "overall": int(getattr(p, "overall", 0)),
+                    "team": str(getattr(p, "team", "")),
+                    "nationality": str(getattr(p, "nationality", "")),
+                    "event": str(getattr(p, "event", "")),
+                    "salary": float(getattr(p, "salary", 0.0)),
+                    "position": str(getattr(p, "position", "")),
+                }
+                for p in selected
+            ],
+            "total_base_ovr": total_ovr,
+            "ovr_bonus": ovr_bonus,
+            "effective_ovr": total_ovr + ovr_bonus,
+            "base_salary": base_salary,
+            "salary_bonus": sal_bonus,
+            "salary_eff": base_salary - sal_bonus,
+            "base_ap": base_ap,
+            "ap_bonus": ap_bonus,
+            "ap_eff": base_ap - ap_bonus,
+            "active_combos": active,
+        }
 
 
 def _dedupe_best_card_per_player(players: Iterable) -> list:

--- a/src/asp/goal2_bruteforce.py
+++ b/src/asp/goal2_bruteforce.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import combinations, permutations
+from typing import Iterable, Sequence
+
+from ..core.data import get_data_loader
+from ..core.models import (
+    ActiveCombo,
+    LineSolution,
+    OptimizationConstraints,
+    OptimizationTarget,
+    Player,
+    Position,
+    RewardType,
+)
+
+
+def _combo_description(conditions: Sequence) -> str:
+    parts: list[str] = []
+    for cond in conditions:
+        parts.append(f"{str(cond.type).upper()}={str(cond.key).upper()}")
+    return " + ".join(parts)
+
+
+def combo_activates(players: Sequence, combo) -> bool:
+    """
+    Order-independent combo activation: returns True iff there exists a bijection
+    between combo conditions and players such that all conditions are satisfied.
+    """
+    conditions = combo.get_conditions()
+    if len(players) != len(conditions):
+        return False
+
+    for perm in permutations(players, len(players)):
+        if all(p.matches_condition(c.type, c.key) for p, c in zip(perm, conditions, strict=True)):
+            return True
+    return False
+
+
+@dataclass(frozen=True)
+class _ScoredLine:
+    solution: LineSolution
+    score_key: tuple
+
+
+class Goal2BruteForceSolver:
+    """
+    Simple Goal 2 solver (interactive suggestions) that brute-forces combinations
+    over a capped candidate pool and scores them. This avoids blocking demo work
+    on a full ASP implementation.
+    """
+
+    def __init__(self, *, data_dir: str = "data/") -> None:
+        self.loader = get_data_loader(data_dir)
+        self.last_candidates_evaluated = 0
+
+    def optimize_forward_line(
+        self,
+        constraints: OptimizationConstraints,
+        target: OptimizationTarget,
+        num_solutions: int = 5,
+    ) -> list[LineSolution]:
+        forwards = self.loader.get_forwards()
+        combos = self.loader.get_forward_combos()
+
+        forwards = self.loader.filter_players(
+            forwards,
+            min_ovr=constraints.min_ovr,
+            team=constraints.required_team,
+            nationality=constraints.required_nationality,
+            event=constraints.required_event,
+            excluded_ids=constraints.excluded_player_ids,
+        )
+
+        if constraints.require_center:
+            forwards = [p for p in forwards if str(getattr(p, "position", "")).upper() == "C"]
+
+        forwards = _dedupe_best_card_per_player(forwards)
+        forwards = _cap_candidates(forwards, target=target, limit=60)
+
+        scored = _score_lines(
+            position=Position.FORWARD,
+            candidates=forwards,
+            combos=combos,
+            constraints=constraints,
+            target=target,
+            k=num_solutions,
+        )
+        self.last_candidates_evaluated = len(forwards)
+        return [s.solution for s in scored]
+
+    def optimize_defense_pair(
+        self,
+        constraints: OptimizationConstraints,
+        target: OptimizationTarget,
+        num_solutions: int = 5,
+    ) -> list[LineSolution]:
+        defense = self.loader.get_defense()
+        combos = self.loader.get_defense_combos()
+
+        defense = self.loader.filter_players(
+            defense,
+            min_ovr=constraints.min_ovr,
+            team=constraints.required_team,
+            nationality=constraints.required_nationality,
+            event=constraints.required_event,
+            excluded_ids=constraints.excluded_player_ids,
+        )
+        defense = _dedupe_best_card_per_player(defense)
+        defense = _cap_candidates(defense, target=target, limit=90)
+
+        scored = _score_lines(
+            position=Position.DEFENSE,
+            candidates=defense,
+            combos=combos,
+            constraints=constraints,
+            target=target,
+            k=num_solutions,
+        )
+        self.last_candidates_evaluated = len(defense)
+        return [s.solution for s in scored]
+
+    def optimize_full_team(
+        self,
+        constraints: OptimizationConstraints,
+        target: OptimizationTarget,
+        num_solutions: int = 5,
+    ) -> list[LineSolution]:
+        raise NotImplementedError("Full-team optimization is not implemented in the brute-force demo solver.")
+
+    def validate_line(self, player_ids: list[int], position_type: str) -> dict:
+        # Reuse the existing logic from the optimize routes placeholder (kept there for now).
+        raise NotImplementedError("Use the /optimize/validate endpoint placeholder for now.")
+
+
+def _dedupe_best_card_per_player(players: Iterable) -> list:
+    best_by_player: dict[int, object] = {}
+    for p in players:
+        pid = int(getattr(p, "player_id", getattr(p, "id")))
+        existing = best_by_player.get(pid)
+        if existing is None or int(getattr(p, "overall", 0)) > int(getattr(existing, "overall", 0)):
+            best_by_player[pid] = p
+    return list(best_by_player.values())
+
+
+def _cap_candidates(players: list, *, target: OptimizationTarget, limit: int) -> list:
+    if not players:
+        return []
+    if target == OptimizationTarget.SALARY:
+        players.sort(key=lambda p: (float(getattr(p, "salary", 0.0)), -int(getattr(p, "overall", 0))))
+    else:
+        players.sort(key=lambda p: (-int(getattr(p, "overall", 0)), float(getattr(p, "salary", 0.0))))
+    return players[:limit]
+
+
+def _score_key_for_target(
+    *,
+    target: OptimizationTarget,
+    effective_ovr: int,
+    salary_eff: float,
+    ap_eff: int,
+) -> tuple:
+    if target == OptimizationTarget.OVR:
+        return (-effective_ovr, salary_eff, ap_eff)
+    if target == OptimizationTarget.SALARY:
+        return (salary_eff, -effective_ovr, ap_eff)
+    if target == OptimizationTarget.AP:
+        return (ap_eff, -effective_ovr, salary_eff)
+    # balanced
+    return (-effective_ovr, salary_eff, ap_eff)
+
+
+def _score_lines(
+    *,
+    position: Position,
+    candidates: list,
+    combos: list,
+    constraints: OptimizationConstraints,
+    target: OptimizationTarget,
+    k: int,
+) -> list[_ScoredLine]:
+    n = 3 if position == Position.FORWARD else 2
+    out: list[_ScoredLine] = []
+
+    for idx, combo_players in enumerate(combinations(candidates, n), start=1):
+        # Ensure no duplicate player_id inside the line
+        pids = [int(getattr(p, "player_id", getattr(p, "id"))) for p in combo_players]
+        if len(set(pids)) != len(pids):
+            continue
+
+        active: list[ActiveCombo] = []
+        ovr_bonus = 0
+        sal_bonus = 0
+        ap_bonus = 0
+
+        for combo in combos:
+            if not combo_activates(combo_players, combo):
+                continue
+            desc = _combo_description(combo.get_conditions())
+            active.append(
+                ActiveCombo(
+                    id=int(combo.id),
+                    reward_type=combo.reward_type,
+                    reward_amount=int(combo.reward_amount),
+                    description=desc,
+                )
+            )
+            if combo.reward_type == RewardType.OVR:
+                ovr_bonus += int(combo.reward_amount)
+            elif combo.reward_type == RewardType.SAL:
+                sal_bonus += int(combo.reward_amount)
+            elif combo.reward_type == RewardType.AP:
+                ap_bonus += int(combo.reward_amount)
+
+        total_base_ovr = sum(int(getattr(p, "overall", 0)) for p in combo_players)
+        base_salary = sum(float(getattr(p, "salary", 0.0)) for p in combo_players)
+        base_ap = 0
+
+        salary_eff = base_salary - sal_bonus
+        ap_eff = base_ap - ap_bonus
+        effective_ovr = total_base_ovr + ovr_bonus
+
+        if constraints.max_salary is not None and salary_eff > float(constraints.max_salary):
+            continue
+        if constraints.max_ap is not None and ap_eff > int(constraints.max_ap):
+            continue
+
+        solution_players = [
+            Player(
+                id=int(p.id),
+                player_id=int(p.player_id),
+                first_name=getattr(p, "first_name", ""),
+                last_name=getattr(p, "last_name", ""),
+                img=str(getattr(p, "img", "")),
+                event=str(getattr(p, "event", "")),
+                nationality=str(getattr(p, "nationality", "")),
+                league=str(getattr(p, "league", "")),
+                team=str(getattr(p, "team", "")),
+                weight=float(getattr(p, "weight", 0.0)),
+                height=int(getattr(p, "height", 0)),
+                salary=float(getattr(p, "salary", 0.0)),
+                overall=int(getattr(p, "overall", 0)),
+                position=str(getattr(p, "position", position.value)),
+            )
+            for p in combo_players
+        ]
+
+        sol = LineSolution(
+            rank=0,  # filled after sorting
+            players=solution_players,
+            total_base_ovr=total_base_ovr,
+            ovr_bonus=ovr_bonus,
+            effective_ovr=effective_ovr,
+            total_salary=salary_eff,
+            total_ap=ap_eff,
+            active_combos=active,
+        )
+        score_key = _score_key_for_target(
+            target=target,
+            effective_ovr=effective_ovr,
+            salary_eff=salary_eff,
+            ap_eff=ap_eff,
+        )
+        out.append(_ScoredLine(solution=sol, score_key=score_key))
+
+    out.sort(key=lambda s: s.score_key)
+    out = out[:k]
+    for i, s in enumerate(out, start=1):
+        s.solution.rank = i
+    return out
+

--- a/tests/test_goal2_bruteforce_solver.py
+++ b/tests/test_goal2_bruteforce_solver.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from src.asp.goal2_bruteforce import combo_activates
+from src.core.models.combos import ComboCondition, ForwardLineCombo
+from src.core.models.enums import RewardType
+
+
+@dataclass(frozen=True)
+class StubPlayer:
+    team: str
+    nationality: str
+    event: str
+
+    def matches_condition(self, condition_type: str, condition_key: str) -> bool:
+        condition_type = condition_type.lower()
+        condition_key = condition_key.upper()
+        if condition_type == "team":
+            return self.team.upper() == condition_key
+        if condition_type == "nationality":
+            return self.nationality.upper() == condition_key
+        if condition_type == "event":
+            return self.event.upper() == condition_key
+        return False
+
+
+def test_combo_activates_is_order_independent_for_forward():
+    # Conditions: TEAM=DET, TEAM=DET, EVENT=FANT
+    combo = ForwardLineCombo(
+        id=1,
+        reward_amount=20,
+        reward_type=RewardType.SAL,
+        condition1=ComboCondition(type="team", key="DET"),
+        condition2=ComboCondition(type="team", key="DET"),
+        condition3=ComboCondition(type="event", key="FANT"),
+    )
+
+    p1 = StubPlayer(team="DET", nationality="CANADA", event="GM")
+    p2 = StubPlayer(team="DET", nationality="USA", event="HH")
+    p3 = StubPlayer(team="CHI", nationality="CANADA", event="FANT")
+
+    assert combo_activates([p1, p2, p3], combo) is True
+    assert combo_activates([p3, p2, p1], combo) is True
+
+
+def test_combo_activates_false_when_condition_missing():
+    combo = ForwardLineCombo(
+        id=1,
+        reward_amount=20,
+        reward_type=RewardType.SAL,
+        condition1=ComboCondition(type="team", key="DET"),
+        condition2=ComboCondition(type="team", key="DET"),
+        condition3=ComboCondition(type="event", key="FANT"),
+    )
+
+    p1 = StubPlayer(team="DET", nationality="CANADA", event="GM")
+    p2 = StubPlayer(team="CHI", nationality="USA", event="HH")
+    p3 = StubPlayer(team="CHI", nationality="CANADA", event="FANT")
+
+    assert combo_activates([p1, p2, p3], combo) is False
+

--- a/tests/test_goal2_bruteforce_solver.py
+++ b/tests/test_goal2_bruteforce_solver.py
@@ -59,4 +59,3 @@ def test_combo_activates_false_when_condition_missing():
     p3 = StubPlayer(team="CHI", nationality="CANADA", event="FANT")
 
     assert combo_activates([p1, p2, p3], combo) is False
-

--- a/tests/test_goal2_optimize_require_center.py
+++ b/tests/test_goal2_optimize_require_center.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from src.api.main import app
+
+
+client = TestClient(app)
+
+
+def test_optimize_forward_line_require_center_enforced():
+    resp = client.post(
+        "/optimize/forward-line",
+        json={
+            "constraints": {"min_ovr": 0, "require_center": True},
+            "optimization_target": "ovr",
+            "num_solutions": 1,
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["success"] is True
+
+    if data["solutions"]:
+        players = data["solutions"][0]["players"]
+        assert any(str(p.get("position", "")).upper() == "C" for p in players)
+

--- a/tests/test_optimize_validate_endpoint.py
+++ b/tests/test_optimize_validate_endpoint.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from src.api.main import app
+from src.core.data import get_data_loader
+
+
+client = TestClient(app)
+
+
+def test_optimize_validate_forward_returns_active_combos_and_totals():
+    loader = get_data_loader()
+    forwards = loader.get_forwards()
+    assert len(forwards) >= 3
+    ids = [int(forwards[0].id), int(forwards[1].id), int(forwards[2].id)]
+
+    resp = client.post("/optimize/validate?position_type=forward", json=ids)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["valid"] is True
+    assert data["total_base_ovr"] >= 0
+    assert "active_combos" in data
+
+
+def test_optimize_validate_defense_returns_active_combos_and_totals():
+    loader = get_data_loader()
+    defense = loader.get_defense()
+    assert len(defense) >= 2
+    ids = [int(defense[0].id), int(defense[1].id)]
+
+    resp = client.post("/optimize/validate?position_type=defense", json=ids)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["valid"] is True
+    assert data["total_base_ovr"] >= 0
+    assert "active_combos" in data
+


### PR DESCRIPTION
Summary
Adds a lightweight Goal 2 solver (src/asp/goal2_bruteforce.py) that suggests forward lines / defense pairs without needing full ASP yet.
Wires it into /optimize/forward-line and /optimize/defense-pair (fallbacks to PlaceholderSolver if import fails).
Computes active combos order-independently and applies SAL/AP bonuses to effective totals.

**Tests**

**venv/bin/python -m pytest -q (99 passed)**


**Notes**

This is intended as a demo unblocker and can be replaced by the real Clingo solver later.