### PR TITLE
Fix: placeholder optimize endpoints return valid Player objects

### DIFF
--- a/src/api/routes/optimize.py
+++ b/src/api/routes/optimize.py
@@ -219,14 +219,19 @@ class PlaceholderSolver(ASPSolverInterface):
             line_players = [
                 Player(
                     id=p.id,
+                    player_id=p.player_id,
                     first_name=p.first_name,
                     last_name=p.last_name,
+                    img=p.img,
                     event=p.event,
                     overall=p.overall,
                     nationality=p.nationality,
                     league=p.league,
                     team=p.team,
-                    position=Position.FORWARD,
+                    weight=p.weight,
+                    height=p.height,
+                    salary=p.salary,
+                    position=p.position,
                 )
                 for p in players
             ]
@@ -284,14 +289,19 @@ class PlaceholderSolver(ASPSolverInterface):
             line_players = [
                 Player(
                     id=p.id,
+                    player_id=p.player_id,
                     first_name=p.first_name,
                     last_name=p.last_name,
+                    img=p.img,
                     event=p.event,
                     overall=p.overall,
                     nationality=p.nationality,
                     league=p.league,
                     team=p.team,
-                    position=Position.DEFENSE,
+                    weight=p.weight,
+                    height=p.height,
+                    salary=p.salary,
+                    position=p.position,
                 )
                 for p in players
             ]
@@ -608,4 +618,3 @@ async def get_solver_status():
             else "Clingo ASP solver active"
         ),
     }
-

--- a/tests/test_optimize_endpoints_smoke.py
+++ b/tests/test_optimize_endpoints_smoke.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from src.api.main import app
+
+
+client = TestClient(app)
+
+
+def test_optimize_forward_line_smoke():
+    resp = client.post(
+        "/optimize/forward-line",
+        json={"constraints": {"min_ovr": 0}, "optimization_target": "ovr", "num_solutions": 1},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["success"] is True
+    assert "solutions" in data
+
+    if data["solutions"]:
+        sol = data["solutions"][0]
+        assert sol["players"], "expected at least one player in solution"
+        player = sol["players"][0]
+        for key in ["id", "player_id", "img", "weight", "height", "salary", "overall", "team", "position"]:
+            assert key in player
+
+
+def test_optimize_defense_pair_smoke():
+    resp = client.post(
+        "/optimize/defense-pair",
+        json={"constraints": {"min_ovr": 0}, "optimization_target": "ovr", "num_solutions": 1},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["success"] is True
+    assert "solutions" in data
+
+    if data["solutions"]:
+        sol = data["solutions"][0]
+        assert sol["players"], "expected at least one player in solution"
+        player = sol["players"][0]
+        for key in ["id", "player_id", "img", "weight", "height", "salary", "overall", "team", "position"]:
+            assert key in player
+


### PR DESCRIPTION
Summary
Fixes /optimize/forward-line and /optimize/defense-pair returning invalid Player payloads (missing required fields like player_id/img/weight/height/salary).
Updates PlaceholderSolver to populate all required Player fields.

**Tests**

**Adds tests/test_optimize_endpoints_smoke.py**
**venv/bin/python -m pytest -q (99 passed)**