### PR TITLE
feat(frontend): add api client, components, hooks, and pages

### DIFF
--- a/docs/FRONTEND_INTEGRATION.md
+++ b/docs/FRONTEND_INTEGRATION.md
@@ -1,18 +1,18 @@
 # Frontend Integration Guide
 
-This guide explains how to connect frontend application to the API.
+This guide explains how to connect the frontend application to the API.
 
-**Target frontend**: Angular v21
+**Frontend Stack**: React 18 + Ant Design + Vite
 
 ## API Base URL
 
 ```
-Development: http://localhost:8000
+Development: http://localhost:8000 (proxied via Vite at /api)
 ```
 
 ## Quick Start
 
-### 1. Start the API Server
+### 1. Start the Backend API Server
 
 ```bash
 cd nhl26-line-combos/backend
@@ -20,14 +20,22 @@ source venv/bin/activate
 uvicorn src.api.main:app --reload --port 8000
 ```
 
-### 2. Verify API is Running
+### 2. Start the Frontend Dev Server
+
+```bash
+cd nhl26-line-combos/frontend
+yarn dev
+# Opens at http://localhost:5173
+```
+
+### 3. Verify API is Running
 
 ```bash
 curl http://localhost:8000/health
 # {"status":"healthy","data":"loaded"}
 ```
 
-### 3. Access API Documentation
+### 4. Access API Documentation
 
 Open http://localhost:8000/docs for interactive Swagger UI.
 
@@ -322,26 +330,50 @@ interface OptimizationResponse {
 }
 ```
 
-## Angular example (HttpClient)
+## React Example (with hooks)
 
 ```typescript
-import { HttpClient, HttpParams } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+// frontend/src/api/client.ts
+const API_BASE = '/api';  // Proxied to localhost:8000
 
-@Injectable({ providedIn: 'root' })
-export class NhlApi {
-  private readonly baseUrl = 'http://localhost:8000';
-
-  constructor(private readonly http: HttpClient) {}
-
-  lookupPlayers(q: string, mode: 'card' | 'player' = 'card') {
-    const params = new HttpParams().set('q', q).set('mode', mode);
-    return this.http.get(`${this.baseUrl}/players/lookup`, { params });
+export async function apiGet<T>(path: string, params?: Record<string, string | number>): Promise<T> {
+  const url = new URL(`${API_BASE}${path}`, window.location.origin);
+  if (params) {
+    Object.entries(params).forEach(([key, value]) => {
+      if (value !== undefined) url.searchParams.append(key, String(value));
+    });
   }
+  const response = await fetch(url.toString());
+  if (!response.ok) throw new Error(`API request failed: ${response.status}`);
+  return response.json();
+}
 
-  optimizeForwardLine(body: unknown) {
-    return this.http.post(`${this.baseUrl}/optimize/forward-line`, body);
-  }
+export async function apiPost<T>(path: string, body: unknown): Promise<T> {
+  const response = await fetch(`${API_BASE}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) throw new Error(`API request failed: ${response.status}`);
+  return response.json();
+}
+
+// Usage in a component
+import { useState, useEffect } from 'react';
+import { apiGet } from './api/client';
+
+function PlayerList() {
+  const [players, setPlayers] = useState([]);
+  
+  useEffect(() => {
+    apiGet('/players/forwards').then(setPlayers);
+  }, []);
+  
+  return (
+    <ul>
+      {players.map(p => <li key={p.id}>{p.first_name} {p.last_name}</li>)}
+    </ul>
+  );
 }
 ```
 

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,3 +1,12 @@
+# Dependencies
+node_modules
+
+# Build output
+dist
+dist-ssr
+build
+.vite
+
 # Logs
 logs
 *.log
@@ -7,18 +16,40 @@ yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
 
-node_modules
-dist
-dist-ssr
+# Environment files
 *.local
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
 
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
 .idea
-.DS_Store
 *.suo
 *.ntvs*
 *.njsproj
 *.sln
 *.sw?
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Testing
+coverage
+
+# TypeScript cache
+*.tsbuildinfo
+
+# Yarn
+.yarn-integrity
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,110 +1,84 @@
-import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
-import { Layout, Menu, Typography, Card, Space, Button } from 'antd';
+import { BrowserRouter, Routes, Route, Link, useLocation } from 'react-router-dom';
+import { Layout, Menu } from 'antd';
 import {
   HomeOutlined,
   UserOutlined,
   TrophyOutlined,
-  SettingOutlined,
+  RocketOutlined,
 } from '@ant-design/icons';
+import { HomePage, PlayersPage, OptimizePage, BestLinesPage } from './pages';
 
 const { Header, Content, Footer } = Layout;
-const { Title, Paragraph } = Typography;
 
-// Placeholder pages - will be implemented in Phase 2
-function HomePage() {
-  return (
-    <Space direction="vertical" size="large" style={{ width: '100%' }}>
-      <Title level={2}>NHL 26 Line Combos Optimizer</Title>
-      <Card title="Welcome">
-        <Paragraph>
-          Find optimal NHL 26 HUT line combinations using Answer Set Programming (ASP) with Clingo.
-        </Paragraph>
-        <Space>
-          <Button type="primary">
-            <Link to="/players">Browse Players</Link>
-          </Button>
-          <Button>
-            <Link to="/optimize">Optimize Lines</Link>
-          </Button>
-        </Space>
-      </Card>
-    </Space>
-  );
-}
+function AppLayout() {
+  const location = useLocation();
 
-function PlayersPage() {
-  return (
-    <Card title="Players">
-      <Paragraph>Player browser will be implemented here.</Paragraph>
-    </Card>
-  );
-}
+  // Determine selected menu key based on current path
+  const getSelectedKey = () => {
+    const path = location.pathname;
+    if (path === '/') return 'home';
+    if (path.startsWith('/players')) return 'players';
+    if (path.startsWith('/optimize')) return 'optimize';
+    if (path.startsWith('/best')) return 'best';
+    return 'home';
+  };
 
-function OptimizePage() {
   return (
-    <Card title="Optimize Lines">
-      <Paragraph>Line optimization form will be implemented here.</Paragraph>
-    </Card>
-  );
-}
-
-function BestLinesPage() {
-  return (
-    <Card title="Best Lines (Goal 1 Results)">
-      <Paragraph>Best line combinations will be displayed here.</Paragraph>
-    </Card>
-  );
-}
-
-function App() {
-  return (
-    <BrowserRouter>
-      <Layout style={{ minHeight: '100vh' }}>
-        <Header style={{ display: 'flex', alignItems: 'center' }}>
-          <div style={{ color: 'white', fontWeight: 'bold', marginRight: 24 }}>
-            NHL26 Line Combos
-          </div>
-          <Menu
-            theme="dark"
-            mode="horizontal"
-            defaultSelectedKeys={['home']}
-            items={[
-              {
-                key: 'home',
-                icon: <HomeOutlined />,
-                label: <Link to="/">Home</Link>,
-              },
-              {
-                key: 'players',
-                icon: <UserOutlined />,
-                label: <Link to="/players">Players</Link>,
-              },
-              {
-                key: 'optimize',
-                icon: <SettingOutlined />,
-                label: <Link to="/optimize">Optimize</Link>,
-              },
-              {
-                key: 'best',
-                icon: <TrophyOutlined />,
-                label: <Link to="/best">Best Lines</Link>,
-              },
-            ]}
-            style={{ flex: 1, minWidth: 0 }}
-          />
-        </Header>
-        <Content style={{ padding: '24px 48px' }}>
+    <Layout style={{ minHeight: '100vh' }}>
+      <Header style={{ display: 'flex', alignItems: 'center', padding: '0 24px' }}>
+        <div style={{ color: 'white', fontWeight: 'bold', marginRight: 32, fontSize: 16 }}>
+          NHL26 Line Combos
+        </div>
+        <Menu
+          theme="dark"
+          mode="horizontal"
+          selectedKeys={[getSelectedKey()]}
+          items={[
+            {
+              key: 'home',
+              icon: <HomeOutlined />,
+              label: <Link to="/">Home</Link>,
+            },
+            {
+              key: 'players',
+              icon: <UserOutlined />,
+              label: <Link to="/players">Players</Link>,
+            },
+            {
+              key: 'optimize',
+              icon: <RocketOutlined />,
+              label: <Link to="/optimize">Optimize</Link>,
+            },
+            {
+              key: 'best',
+              icon: <TrophyOutlined />,
+              label: <Link to="/best">Best Lines</Link>,
+            },
+          ]}
+          style={{ flex: 1, minWidth: 0 }}
+        />
+      </Header>
+      <Content style={{ padding: '24px 48px' }}>
+        <div style={{ background: '#fff', padding: 24, minHeight: 280, borderRadius: 8 }}>
           <Routes>
             <Route path="/" element={<HomePage />} />
             <Route path="/players" element={<PlayersPage />} />
             <Route path="/optimize" element={<OptimizePage />} />
             <Route path="/best" element={<BestLinesPage />} />
           </Routes>
-        </Content>
-        <Footer style={{ textAlign: 'center' }}>
-          NHL 26 Line Combos Optimizer - KRR Final Project - Jönköping University
-        </Footer>
-      </Layout>
+        </div>
+      </Content>
+      <Footer style={{ textAlign: 'center' }}>
+        NHL 26 Line Combos Optimizer - KRR Final Project - Jönköping University
+      </Footer>
+    </Layout>
+  );
+}
+
+function App() {
+  return (
+    <BrowserRouter>
+      <AppLayout />
     </BrowserRouter>
   );
 }

--- a/frontend/src/api/best.ts
+++ b/frontend/src/api/best.ts
@@ -1,0 +1,47 @@
+/**
+ * Best Lines (Goal 1 Results) API module
+ */
+
+import { apiGet } from './client';
+import type { Goal1Run, BestLinesResponse } from './types';
+
+export interface RunListResponse {
+  runs: Goal1Run[];
+  total: number;
+}
+
+// List all Goal 1 runs
+export function listRuns(
+  position_type?: 'forward' | 'defense',
+  optimization_mode?: string
+): Promise<RunListResponse> {
+  return apiGet<RunListResponse>('/best/runs', { position_type, optimization_mode });
+}
+
+// Get best lines for a position and optimization mode
+export function getBestLines(
+  position: 'forward' | 'defense',
+  mode: 'ovr' | 'sal' | 'ap' | 'ovr_sal' | 'ovr_sal_ap',
+  options?: {
+    run_id?: number;
+    limit?: number;
+    offset?: number;
+  }
+): Promise<BestLinesResponse> {
+  return apiGet<BestLinesResponse>(`/best/${position}/${mode}`, options);
+}
+
+// Get summary for best lines
+export interface BestLinesSummary {
+  success: boolean;
+  run: Goal1Run | null;
+  total_lines: number;
+  top_scores: number[];
+}
+
+export function getBestLinesSummary(
+  position: 'forward' | 'defense',
+  mode: 'ovr' | 'sal' | 'ap' | 'ovr_sal' | 'ovr_sal_ap'
+): Promise<BestLinesSummary> {
+  return apiGet<BestLinesSummary>(`/best/${position}/${mode}/summary`);
+}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,68 @@
+/**
+ * Base API client with error handling
+ */
+
+const API_BASE = '/api';  // Proxied to localhost:8000 via Vite
+
+export class ApiError extends Error {
+  status: number;
+  detail?: string;
+
+  constructor(message: string, status: number, detail?: string) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.detail = detail;
+  }
+}
+
+async function handleResponse<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    let detail: string | undefined;
+    try {
+      const errorData = await response.json();
+      detail = errorData.detail || errorData.message;
+    } catch {
+      detail = response.statusText;
+    }
+    throw new ApiError(
+      `API request failed: ${response.status}`,
+      response.status,
+      detail
+    );
+  }
+  return response.json();
+}
+
+export async function apiGet<T>(path: string, params?: Record<string, string | number | boolean | undefined>): Promise<T> {
+  const url = new URL(`${API_BASE}${path}`, window.location.origin);
+  
+  if (params) {
+    Object.entries(params).forEach(([key, value]) => {
+      if (value !== undefined && value !== null) {
+        url.searchParams.append(key, String(value));
+      }
+    });
+  }
+  
+  const response = await fetch(url.toString());
+  return handleResponse<T>(response);
+}
+
+export async function apiPost<T>(path: string, body: unknown): Promise<T> {
+  const response = await fetch(`${API_BASE}${path}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+  return handleResponse<T>(response);
+}
+
+export async function apiDelete<T>(path: string): Promise<T> {
+  const response = await fetch(`${API_BASE}${path}`, {
+    method: 'DELETE',
+  });
+  return handleResponse<T>(response);
+}

--- a/frontend/src/api/combos.ts
+++ b/frontend/src/api/combos.ts
@@ -1,0 +1,21 @@
+/**
+ * Line Combos API module
+ */
+
+import { apiGet } from './client';
+import type { LineCombo, Player } from './types';
+
+// Get all forward line combos
+export function getForwardCombos(): Promise<LineCombo[]> {
+  return apiGet<LineCombo[]>('/combos/forward');
+}
+
+// Get all defense line combos
+export function getDefenseCombos(): Promise<LineCombo[]> {
+  return apiGet<LineCombo[]>('/combos/defense');
+}
+
+// Get players matching a specific combo
+export function getMatchingPlayers(comboId: number): Promise<Player[]> {
+  return apiGet<Player[]>(`/combos/forward/${comboId}/matching-players`);
+}

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,0 +1,15 @@
+/**
+ * API module exports
+ */
+
+// Base client
+export { apiGet, apiPost, apiDelete, ApiError } from './client';
+
+// Types
+export * from './types';
+
+// API modules
+export * as playersApi from './players';
+export * as combosApi from './combos';
+export * as optimizeApi from './optimize';
+export * as bestApi from './best';

--- a/frontend/src/api/optimize.ts
+++ b/frontend/src/api/optimize.ts
@@ -1,0 +1,56 @@
+/**
+ * Optimization API module
+ */
+
+import { apiPost, apiGet } from './client';
+import type { OptimizationRequest, OptimizationResponse } from './types';
+
+// Optimize forward line
+export function optimizeForwardLine(request: OptimizationRequest): Promise<OptimizationResponse> {
+  return apiPost<OptimizationResponse>('/optimize/forward-line', request);
+}
+
+// Optimize defense pair
+export function optimizeDefensePair(request: OptimizationRequest): Promise<OptimizationResponse> {
+  return apiPost<OptimizationResponse>('/optimize/defense-pair', request);
+}
+
+// Optimize full team
+export function optimizeFullTeam(request: OptimizationRequest): Promise<OptimizationResponse> {
+  return apiPost<OptimizationResponse>('/optimize/full-team', request);
+}
+
+// Validate a user-selected line
+export interface ValidateRequest {
+  player_ids: number[];
+  position_type: 'forward' | 'defense';
+}
+
+export interface ValidateResponse {
+  valid: boolean;
+  active_combos: Array<{
+    id: number;
+    reward_type: string;
+    reward_amount: number;
+    description: string;
+  }>;
+  total_bonus: {
+    ovr: number;
+    salary: number;
+    ap: number;
+  };
+}
+
+export function validateLine(request: ValidateRequest): Promise<ValidateResponse> {
+  return apiPost<ValidateResponse>('/optimize/validate', request);
+}
+
+// Check if ASP solver is ready
+export interface SolverStatus {
+  asp_ready: boolean;
+  message: string;
+}
+
+export function getSolverStatus(): Promise<SolverStatus> {
+  return apiGet<SolverStatus>('/optimize/status');
+}

--- a/frontend/src/api/players.ts
+++ b/frontend/src/api/players.ts
@@ -1,0 +1,92 @@
+/**
+ * Players API module
+ */
+
+import { apiGet } from './client';
+import type { Player, LookupOption, DatasetStats } from './types';
+
+export interface PlayerFilters {
+  min_ovr?: number;
+  max_ovr?: number;
+  team?: string;
+  nationality?: string;
+  event?: string;
+  limit?: number;
+  offset?: number;
+  [key: string]: string | number | boolean | undefined;
+}
+
+// Get forwards with optional filters
+export function getForwards(filters?: PlayerFilters): Promise<Player[]> {
+  return apiGet<Player[]>('/players/forwards', filters);
+}
+
+// Get defense players with optional filters
+export function getDefense(filters?: PlayerFilters): Promise<Player[]> {
+  return apiGet<Player[]>('/players/defense', filters);
+}
+
+// Get goalies with optional filters
+export function getGoalies(filters?: PlayerFilters): Promise<Player[]> {
+  return apiGet<Player[]>('/players/goalies', filters);
+}
+
+// Search forwards by name
+export function searchForwards(q: string, filters?: PlayerFilters): Promise<Player[]> {
+  return apiGet<Player[]>('/players/forwards/search', { q, ...filters });
+}
+
+// Search defense by name
+export function searchDefense(q: string, filters?: PlayerFilters): Promise<Player[]> {
+  return apiGet<Player[]>('/players/defense/search', { q, ...filters });
+}
+
+// Search goalies by name
+export function searchGoalies(q: string, filters?: PlayerFilters): Promise<Player[]> {
+  return apiGet<Player[]>('/players/goalies/search', { q, ...filters });
+}
+
+// Lookup players for autocomplete
+export function lookupPlayers(
+  q: string, 
+  mode: 'card' | 'player' = 'card',
+  position?: 'FWD' | 'DEF' | 'G'
+): Promise<LookupOption[]> {
+  return apiGet<LookupOption[]>('/players/lookup', { q, mode, position });
+}
+
+// Get all cards for a specific player
+export function getForwardCards(playerId: number): Promise<Player[]> {
+  return apiGet<Player[]>(`/players/forwards/cards/${playerId}`);
+}
+
+export function getDefenseCards(playerId: number): Promise<Player[]> {
+  return apiGet<Player[]>(`/players/defense/cards/${playerId}`);
+}
+
+export function getGoalieCards(playerId: number): Promise<Player[]> {
+  return apiGet<Player[]>(`/players/goalies/cards/${playerId}`);
+}
+
+// Get dataset statistics
+export function getStats(): Promise<DatasetStats> {
+  return apiGet<DatasetStats>('/stats/');
+}
+
+// Get available teams
+export async function getTeams(): Promise<string[]> {
+  const response = await apiGet<{ teams: string[] }>('/stats/teams');
+  return response.teams;
+}
+
+// Get available nationalities
+export async function getNationalities(): Promise<string[]> {
+  const response = await apiGet<{ nationalities: string[] }>('/stats/nationalities');
+  return response.nationalities;
+}
+
+// Get available events
+export async function getEvents(): Promise<string[]> {
+  const response = await apiGet<{ events: string[] }>('/stats/events');
+  return response.events;
+}

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1,0 +1,161 @@
+// Player types
+export interface Player {
+  id: number;  // unique card ID (auto-increment)
+  player_id: number;  // real player ID (shared across cards)
+  first_name: string;
+  last_name: string;
+  img: string;
+  position: 'FWD' | 'DEF' | 'G';
+  salary: number;
+  event: string;
+  overall: number;
+  nationality: string;
+  league: string;
+  team: string;
+  weight: number;
+  height: number;
+}
+
+export interface LookupOption {
+  value: number;  // either card id or player_id
+  value_type: 'card' | 'player';
+  player_id: number;
+  position: 'FWD' | 'DEF' | 'G';
+  overall: number;
+  event: string;
+  label: string;
+}
+
+// Combo types
+export interface ComboCondition {
+  type: 'team' | 'nationality' | 'event';
+  key: string;
+}
+
+export interface LineCombo {
+  id: number;
+  reward_amount: number;
+  reward_type: 'OVR' | 'SAL' | 'AP';
+  condition1: ComboCondition;
+  condition2: ComboCondition;
+  condition3?: ComboCondition;  // Only for forward combos
+}
+
+// Optimization types
+export interface OptimizationConstraints {
+  min_ovr?: number;
+  max_salary?: number | null;
+  max_ap?: number | null;
+  require_center?: boolean;
+  excluded_player_ids?: number[];
+  required_team?: string | null;
+  required_nationality?: string | null;
+  required_event?: string | null;
+}
+
+export interface OptimizationRequest {
+  constraints?: OptimizationConstraints;
+  optimization_target?: 'ovr' | 'salary' | 'ap' | 'balanced';
+  num_solutions?: number;
+}
+
+export interface ActiveCombo {
+  id: number;
+  reward_type: 'OVR' | 'SAL' | 'AP';
+  reward_amount: number;
+  description: string;
+}
+
+export interface LineSolution {
+  rank: number;
+  players: Player[];
+  total_base_ovr: number;
+  ovr_bonus: number;
+  effective_ovr: number;
+  total_salary: number;
+  total_ap: number;
+  active_combos: ActiveCombo[];
+}
+
+export interface OptimizationResponse {
+  success: boolean;
+  message: string;
+  solutions: LineSolution[];
+  computation_time_ms: number;
+  candidates_evaluated: number;
+}
+
+// Goal 1 / Best Lines types
+export interface Goal1Run {
+  id: number;
+  run_timestamp: string;
+  position_type: 'forward' | 'defense';
+  optimization_mode: 'ovr' | 'sal' | 'ap' | 'ovr_sal' | 'ovr_sal_ap';
+  parameters: Record<string, unknown>;
+  dataset_hash?: string;
+}
+
+export interface PlayerInfo {
+  id: number;
+  player_id: number;
+  first_name: string;
+  last_name: string;
+  overall: number;
+  team: string;
+  nationality: string;
+  event: string;
+  position: string;
+  salary: number;
+}
+
+export interface ConcreteLineResponse {
+  id: number;
+  players: PlayerInfo[];
+  activated_combo_ids: number[];
+  total_ovr: number;
+  total_salary: number;
+  total_ap: number;
+  ranking_score: number;
+}
+
+export interface BestLinesResponse {
+  success: boolean;
+  run: Goal1Run | null;
+  position_type: string;
+  optimization_mode: string;
+  total_lines: number;
+  lines: ConcreteLineResponse[];
+}
+
+// Stats types
+export interface DatasetStats {
+  players: {
+    forwards: number;
+    defense: number;
+    goalies: number;
+    total: number;
+  };
+  combos: {
+    forward_combos: number;
+    defense_combos: number;
+    total: number;
+  };
+  teams: string[];
+  nationalities: string[];
+}
+
+// API response wrapper
+export interface ApiResponse<T> {
+  success: boolean;
+  data?: T;
+  error?: string;
+}
+
+// Pagination
+export interface PaginatedResponse<T> {
+  items: T[];
+  total: number;
+  page: number;
+  limit: number;
+  has_more: boolean;
+}

--- a/frontend/src/components/ComboCard.tsx
+++ b/frontend/src/components/ComboCard.tsx
@@ -1,0 +1,87 @@
+/**
+ * ComboCard - Display a line combination with its conditions and rewards
+ */
+
+import { Card, Tag, Space, Typography, Flex } from 'antd';
+import { GiftOutlined, TeamOutlined, GlobalOutlined, CalendarOutlined } from '@ant-design/icons';
+import type { LineCombo, ComboCondition } from '../api/types';
+
+const { Text } = Typography;
+
+interface ComboCardProps {
+  combo: LineCombo;
+  onClick?: () => void;
+}
+
+// Get icon for condition type
+function getConditionIcon(type: string) {
+  switch (type) {
+    case 'team': return <TeamOutlined />;
+    case 'nationality': return <GlobalOutlined />;
+    case 'event': return <CalendarOutlined />;
+    default: return null;
+  }
+}
+
+// Get color for reward type
+function getRewardColor(type: string): string {
+  switch (type) {
+    case 'OVR': return 'green';
+    case 'SAL': return 'blue';
+    case 'AP': return 'purple';
+    default: return 'default';
+  }
+}
+
+// Get condition tag color
+function getConditionColor(type: string): string {
+  switch (type) {
+    case 'team': return 'cyan';
+    case 'nationality': return 'magenta';
+    case 'event': return 'orange';
+    default: return 'default';
+  }
+}
+
+function ConditionTag({ condition }: { condition: ComboCondition }) {
+  return (
+    <Tag color={getConditionColor(condition.type)} icon={getConditionIcon(condition.type)}>
+      {condition.type}: {condition.key}
+    </Tag>
+  );
+}
+
+export function ComboCard({ combo, onClick }: ComboCardProps) {
+  const conditions = [combo.condition1, combo.condition2];
+  if (combo.condition3) {
+    conditions.push(combo.condition3);
+  }
+
+  return (
+    <Card
+      size="small"
+      hoverable={!!onClick}
+      onClick={onClick}
+      style={{ cursor: onClick ? 'pointer' : 'default' }}
+      title={
+        <Space>
+          <Text type="secondary">#{combo.id}</Text>
+          <Tag color={getRewardColor(combo.reward_type)} icon={<GiftOutlined />}>
+            +{combo.reward_amount} {combo.reward_type}
+          </Tag>
+        </Space>
+      }
+    >
+      <Flex vertical gap="small" style={{ width: '100%' }}>
+        <Text type="secondary">Conditions:</Text>
+        <Space wrap>
+          {conditions.map((condition, idx) => (
+            <ConditionTag key={idx} condition={condition} />
+          ))}
+        </Space>
+      </Flex>
+    </Card>
+  );
+}
+
+export default ComboCard;

--- a/frontend/src/components/LineDisplay.tsx
+++ b/frontend/src/components/LineDisplay.tsx
@@ -1,0 +1,139 @@
+/**
+ * LineDisplay - Display a line of players with stats and bonuses
+ */
+
+import { Card, Row, Col, Tag, Space, Typography, Divider, Statistic } from 'antd';
+import { TrophyOutlined, TeamOutlined } from '@ant-design/icons';
+import type { Player, PlayerInfo, ConcreteLineResponse, LineSolution } from '../api/types';
+import { PlayerCard } from './PlayerCard';
+
+const { Text } = Typography;
+
+interface LineDisplayProps {
+  // Either a LineSolution (from optimization) or ConcreteLineResponse (from Goal 1)
+  line: LineSolution | ConcreteLineResponse;
+  rank?: number;
+  showDetails?: boolean;
+}
+
+// Type guard to check if it's a LineSolution
+function isLineSolution(line: LineSolution | ConcreteLineResponse): line is LineSolution {
+  return 'total_base_ovr' in line;
+}
+
+export function LineDisplay({ line, rank, showDetails = true }: LineDisplayProps) {
+  const players = line.players;
+  const isOptimization = isLineSolution(line);
+
+  return (
+    <Card
+      title={
+        <Space>
+          <TeamOutlined />
+          {rank !== undefined && <Tag color="blue">#{rank}</Tag>}
+          <Text strong>
+            {players.map((p) => `${p.first_name.charAt(0)}. ${p.last_name}`).join(' - ')}
+          </Text>
+        </Space>
+      }
+      extra={
+        <Space>
+          {isOptimization ? (
+            <Tag color="green" style={{ fontSize: 14, padding: '4px 8px' }}>
+              {line.effective_ovr} Effective OVR
+            </Tag>
+          ) : (
+            <Tag color="green" style={{ fontSize: 14, padding: '4px 8px' }}>
+              {line.ranking_score.toFixed(1)} Score
+            </Tag>
+          )}
+        </Space>
+      }
+    >
+      {/* Players */}
+      <Row gutter={[8, 8]}>
+        {players.map((player, idx) => (
+          <Col key={idx} xs={24} sm={12} md={8} lg={players.length <= 2 ? 12 : 8}>
+            <PlayerCard player={player as Player | PlayerInfo} compact />
+          </Col>
+        ))}
+      </Row>
+
+      {showDetails && (
+        <>
+          <Divider />
+          
+          {/* Stats */}
+          <Row gutter={16}>
+            <Col span={6}>
+              <Statistic
+                title="Total OVR"
+                value={isOptimization ? line.total_base_ovr : line.total_ovr}
+              />
+            </Col>
+            {isOptimization && (
+              <Col span={6}>
+                <Statistic
+                  title="OVR Bonus"
+                  value={line.ovr_bonus}
+                  prefix="+"
+                />
+              </Col>
+            )}
+            <Col span={6}>
+              <Statistic
+                title="Salary"
+                value={isOptimization ? line.total_salary : line.total_salary}
+                suffix="K"
+              />
+            </Col>
+            <Col span={6}>
+              <Statistic
+                title="AP Cost"
+                value={isOptimization ? line.total_ap : line.total_ap}
+              />
+            </Col>
+          </Row>
+
+          {/* Active Combos */}
+          {isOptimization && line.active_combos && line.active_combos.length > 0 && (
+            <>
+              <Divider>
+                <Space>
+                  <TrophyOutlined />
+                  Active Combos
+                </Space>
+              </Divider>
+              <Space wrap>
+                {line.active_combos.map((combo, idx) => (
+                  <Tag key={idx} color="gold">
+                    +{combo.reward_amount} {combo.reward_type}: {combo.description}
+                  </Tag>
+                ))}
+              </Space>
+            </>
+          )}
+
+          {/* For ConcreteLineResponse, show combo IDs */}
+          {!isOptimization && line.activated_combo_ids && line.activated_combo_ids.length > 0 && (
+            <>
+              <Divider>
+                <Space>
+                  <TrophyOutlined />
+                  Active Combo IDs
+                </Space>
+              </Divider>
+              <Space wrap>
+                {line.activated_combo_ids.map((id) => (
+                  <Tag key={id} color="gold">Combo #{id}</Tag>
+                ))}
+              </Space>
+            </>
+          )}
+        </>
+      )}
+    </Card>
+  );
+}
+
+export default LineDisplay;

--- a/frontend/src/components/PlayerCard.tsx
+++ b/frontend/src/components/PlayerCard.tsx
@@ -1,0 +1,95 @@
+/**
+ * PlayerCard - Display player information in a card format
+ */
+
+import { Card, Tag, Space, Typography, Statistic, Row, Col } from 'antd';
+import { UserOutlined } from '@ant-design/icons';
+import type { Player, PlayerInfo } from '../api/types';
+
+const { Text } = Typography;
+
+interface PlayerCardProps {
+  player: Player | PlayerInfo;
+  compact?: boolean;
+  onClick?: () => void;
+}
+
+// Get color based on overall rating
+function getOvrColor(ovr: number): string {
+  if (ovr >= 90) return '#52c41a';  // green
+  if (ovr >= 85) return '#1890ff';  // blue
+  if (ovr >= 80) return '#722ed1';  // purple
+  if (ovr >= 75) return '#faad14';  // gold
+  return '#8c8c8c';  // gray
+}
+
+// Get position color
+function getPositionColor(position: string): string {
+  switch (position) {
+    case 'FWD': return 'blue';
+    case 'DEF': return 'green';
+    case 'G': return 'orange';
+    default: return 'default';
+  }
+}
+
+export function PlayerCard({ player, compact = false, onClick }: PlayerCardProps) {
+  const fullName = `${player.first_name} ${player.last_name}`;
+  
+  if (compact) {
+    return (
+      <Card 
+        size="small" 
+        hoverable={!!onClick}
+        onClick={onClick}
+        style={{ cursor: onClick ? 'pointer' : 'default' }}
+      >
+        <Space>
+          <Tag color={getPositionColor(player.position)}>{player.position}</Tag>
+          <Text strong>{fullName}</Text>
+          <Tag color={getOvrColor(player.overall)}>{player.overall} OVR</Tag>
+          <Text type="secondary">{player.team}</Text>
+        </Space>
+      </Card>
+    );
+  }
+
+  return (
+    <Card
+      hoverable={!!onClick}
+      onClick={onClick}
+      style={{ cursor: onClick ? 'pointer' : 'default' }}
+      title={
+        <Space>
+          <UserOutlined />
+          <span>{fullName}</span>
+          <Tag color={getPositionColor(player.position)}>{player.position}</Tag>
+        </Space>
+      }
+      extra={
+        <Tag color={getOvrColor(player.overall)} style={{ fontSize: 16, padding: '4px 12px' }}>
+          {player.overall} OVR
+        </Tag>
+      }
+    >
+      <Row gutter={16}>
+        <Col span={8}>
+          <Statistic title="Salary" value={player.salary} suffix="K" />
+        </Col>
+        <Col span={8}>
+          <Statistic title="Team" value={player.team} />
+        </Col>
+        <Col span={8}>
+          <Statistic title="Nationality" value={player.nationality} />
+        </Col>
+      </Row>
+      {'event' in player && player.event && (
+        <div style={{ marginTop: 12 }}>
+          <Tag color="purple">{player.event}</Tag>
+        </div>
+      )}
+    </Card>
+  );
+}
+
+export default PlayerCard;

--- a/frontend/src/components/PlayerSearch.tsx
+++ b/frontend/src/components/PlayerSearch.tsx
@@ -1,0 +1,86 @@
+/**
+ * PlayerSearch - Autocomplete player lookup component
+ */
+
+import { useState, useCallback } from 'react';
+import { AutoComplete, Input, Space, Tag, Typography } from 'antd';
+import { SearchOutlined, UserOutlined } from '@ant-design/icons';
+import { lookupPlayers } from '../api/players';
+import type { LookupOption } from '../api/types';
+import { useLazyApi } from '../hooks/useApi';
+
+const { Text } = Typography;
+
+interface PlayerSearchProps {
+  mode?: 'card' | 'player';
+  position?: 'FWD' | 'DEF' | 'G';
+  placeholder?: string;
+  onSelect?: (option: LookupOption) => void;
+  style?: React.CSSProperties;
+}
+
+export function PlayerSearch({
+  mode = 'card',
+  position,
+  placeholder = 'Search players...',
+  onSelect,
+  style,
+}: PlayerSearchProps) {
+  const [searchValue, setSearchValue] = useState('');
+  const { data: options, loading, execute } = useLazyApi(
+    (q: string) => lookupPlayers(q, mode, position)
+  );
+
+  const handleSearch = useCallback(
+    async (value: string) => {
+      setSearchValue(value);
+      if (value.length >= 2) {
+        await execute(value);
+      }
+    },
+    [execute]
+  );
+
+  const handleSelect = useCallback(
+    (_value: string, option: { data: LookupOption }) => {
+      if (onSelect) {
+        onSelect(option.data);
+      }
+      setSearchValue('');
+    },
+    [onSelect]
+  );
+
+  const renderOption = (option: LookupOption) => ({
+    value: String(option.value),
+    label: (
+      <Space>
+        <UserOutlined />
+        <Text strong>{option.label}</Text>
+        <Tag color="blue">{option.position}</Tag>
+        <Tag color="green">{option.overall} OVR</Tag>
+        {option.event && <Tag color="purple">{option.event}</Tag>}
+      </Space>
+    ),
+    data: option,
+  });
+
+  return (
+    <AutoComplete
+      style={{ width: '100%', ...style }}
+      options={options?.map(renderOption) || []}
+      onSearch={handleSearch}
+      onSelect={handleSelect}
+      value={searchValue}
+      notFoundContent={loading ? 'Searching...' : searchValue.length >= 2 ? 'No players found' : null}
+    >
+      <Input
+        prefix={<SearchOutlined />}
+        placeholder={placeholder}
+        allowClear
+      />
+    </AutoComplete>
+  );
+}
+
+export default PlayerSearch;

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Component exports
+ */
+
+export { PlayerCard } from './PlayerCard';
+export { LineDisplay } from './LineDisplay';
+export { ComboCard } from './ComboCard';
+export { PlayerSearch } from './PlayerSearch';

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -1,0 +1,97 @@
+/**
+ * Custom hooks for API data fetching
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { ApiError } from '../api/client';
+
+export interface UseApiState<T> {
+  data: T | null;
+  loading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+/**
+ * Hook for fetching data from the API
+ */
+export function useApi<T>(
+  fetchFn: () => Promise<T>,
+  deps: unknown[] = []
+): UseApiState<T> {
+  const [data, setData] = useState<T | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetch = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await fetchFn();
+      setData(result);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.detail || err.message);
+      } else if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError('An unexpected error occurred');
+      }
+    } finally {
+      setLoading(false);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+
+  useEffect(() => {
+    fetch();
+  }, [fetch]);
+
+  return { data, loading, error, refetch: fetch };
+}
+
+/**
+ * Hook for lazy fetching (manual trigger)
+ */
+export function useLazyApi<T, P extends unknown[]>(
+  fetchFn: (...args: P) => Promise<T>
+): {
+  data: T | null;
+  loading: boolean;
+  error: string | null;
+  execute: (...args: P) => Promise<T | null>;
+  reset: () => void;
+} {
+  const [data, setData] = useState<T | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const execute = useCallback(async (...args: P): Promise<T | null> => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await fetchFn(...args);
+      setData(result);
+      return result;
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.detail || err.message);
+      } else if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError('An unexpected error occurred');
+      }
+      return null;
+    } finally {
+      setLoading(false);
+    }
+  }, [fetchFn]);
+
+  const reset = useCallback(() => {
+    setData(null);
+    setError(null);
+    setLoading(false);
+  }, []);
+
+  return { data, loading, error, execute, reset };
+}

--- a/frontend/src/pages/BestLinesPage.tsx
+++ b/frontend/src/pages/BestLinesPage.tsx
@@ -1,0 +1,196 @@
+/**
+ * BestLinesPage - Display Goal 1 results (best line combinations)
+ */
+
+import { useState } from 'react';
+import {
+  Card,
+  Tabs,
+  Select,
+  Flex,
+  Typography,
+  Row,
+  Col,
+  Alert,
+  Empty,
+  Spin,
+  Statistic,
+  Pagination,
+} from 'antd';
+import { TrophyOutlined } from '@ant-design/icons';
+import { useApi } from '../hooks/useApi';
+import { getBestLines, listRuns } from '../api/best';
+import { LineDisplay } from '../components/LineDisplay';
+
+const { Title, Text } = Typography;
+
+type PositionType = 'forward' | 'defense';
+type OptimizationMode = 'ovr' | 'sal' | 'ap' | 'ovr_sal' | 'ovr_sal_ap';
+
+const OPTIMIZATION_MODES: { value: OptimizationMode; label: string }[] = [
+  { value: 'ovr', label: 'Best OVR' },
+  { value: 'sal', label: 'Best Salary' },
+  { value: 'ap', label: 'Best AP' },
+  { value: 'ovr_sal', label: 'OVR + Salary' },
+  { value: 'ovr_sal_ap', label: 'OVR + Salary + AP' },
+];
+
+export function BestLinesPage() {
+  const [positionType, setPositionType] = useState<PositionType>('forward');
+  const [mode, setMode] = useState<OptimizationMode>('ovr');
+  const [page, setPage] = useState(1);
+  const pageSize = 10;
+
+  // Fetch runs list (for future use in run selector)
+  const { loading: loadingRuns } = useApi(
+    () => listRuns(positionType),
+    [positionType]
+  );
+
+  // Fetch best lines
+  const { data: linesData, loading: loadingLines, error } = useApi(
+    () => getBestLines(positionType, mode, {
+      limit: pageSize,
+      offset: (page - 1) * pageSize,
+    }),
+    [positionType, mode, page]
+  );
+
+  const handlePositionChange = (key: string) => {
+    setPositionType(key as PositionType);
+    setPage(1);
+  };
+
+  const handleModeChange = (value: OptimizationMode) => {
+    setMode(value);
+    setPage(1);
+  };
+
+  return (
+    <Flex vertical gap="large" style={{ width: '100%' }}>
+      <Title level={2}>
+        <TrophyOutlined /> Best Lines (Goal 1 Results)
+      </Title>
+
+      <Text type="secondary">
+        Pre-computed optimal line combinations ranked by different optimization criteria.
+      </Text>
+
+      {/* Position Tabs */}
+      <Card>
+        <Tabs
+          activeKey={positionType}
+          onChange={handlePositionChange}
+          items={[
+            {
+              key: 'forward',
+              label: 'Forward Lines',
+            },
+            {
+              key: 'defense',
+              label: 'Defense Pairs',
+            },
+          ]}
+        />
+
+        {/* Mode Selector */}
+        <Row gutter={16} align="middle" style={{ marginTop: 16 }}>
+          <Col>
+            <Text strong>Optimization Mode:</Text>
+          </Col>
+          <Col>
+            <Select
+              value={mode}
+              onChange={handleModeChange}
+              options={OPTIMIZATION_MODES}
+              style={{ width: 200 }}
+            />
+          </Col>
+        </Row>
+      </Card>
+
+      {/* Run Info */}
+      {linesData?.run && (
+        <Card size="small">
+          <Row gutter={16}>
+            <Col span={6}>
+              <Statistic
+                title="Run ID"
+                value={linesData.run.id}
+              />
+            </Col>
+            <Col span={6}>
+              <Statistic
+                title="Total Lines"
+                value={linesData.total_lines}
+              />
+            </Col>
+            <Col span={12}>
+              <Statistic
+                title="Run Timestamp"
+                value={new Date(linesData.run.run_timestamp).toLocaleString()}
+              />
+            </Col>
+          </Row>
+        </Card>
+      )}
+
+      {/* Error */}
+      {error && (
+        <Alert
+          title="Failed to load best lines"
+          description={error}
+          type="error"
+          showIcon
+        />
+      )}
+
+      {/* Loading */}
+      {(loadingLines || loadingRuns) && (
+        <div style={{ textAlign: 'center', padding: 40 }}>
+          <Spin size="large" />
+        </div>
+      )}
+
+      {/* No Data */}
+      {!loadingLines && !error && (!linesData?.lines || linesData.lines.length === 0) && (
+        <Empty
+          description={
+            <span>
+              No best lines found for {positionType} / {mode}.
+              <br />
+              Run the Goal 1 pipeline to generate results.
+            </span>
+          }
+        />
+      )}
+
+      {/* Lines List */}
+      {!loadingLines && linesData?.lines && linesData.lines.length > 0 && (
+        <Flex vertical gap="middle" style={{ width: '100%' }}>
+          {linesData.lines.map((line, idx) => (
+            <LineDisplay
+              key={line.id}
+              line={line}
+              rank={(page - 1) * pageSize + idx + 1}
+            />
+          ))}
+
+          {/* Pagination */}
+          <Row justify="center" style={{ marginTop: 16 }}>
+            <Pagination
+              current={page}
+              pageSize={pageSize}
+              total={linesData.total_lines}
+              onChange={setPage}
+              showSizeChanger={false}
+              showTotal={(total) => `${total} lines total`}
+            />
+          </Row>
+        </Flex>
+      )}
+    </Flex>
+  );
+}
+
+export default BestLinesPage;

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,0 +1,150 @@
+/**
+ * HomePage - Dashboard with statistics
+ */
+
+import { Row, Col, Card, Statistic, Typography, Flex, Space, Button, Alert } from 'antd';
+import {
+  UserOutlined,
+  TeamOutlined,
+  TrophyOutlined,
+  RocketOutlined,
+  SearchOutlined,
+} from '@ant-design/icons';
+import { Link } from 'react-router-dom';
+import { useApi } from '../hooks/useApi';
+import { getStats } from '../api/players';
+
+const { Title, Paragraph } = Typography;
+
+export function HomePage() {
+  const { data: stats, loading, error } = useApi(() => getStats(), []);
+
+  return (
+    <Flex vertical gap="large" style={{ width: '100%' }}>
+      <div>
+        <Title level={2}>NHL 26 Line Combos Optimizer</Title>
+        <Paragraph type="secondary">
+          Find optimal NHL 26 HUT line combinations using Answer Set Programming (ASP) with Clingo.
+        </Paragraph>
+      </div>
+
+      {error && (
+        <Alert
+          title="Failed to load statistics"
+          description={error}
+          type="error"
+          showIcon
+        />
+      )}
+
+      {/* Statistics Cards */}
+      <Row gutter={[16, 16]}>
+        <Col xs={12} sm={8} md={6} lg={4}>
+          <Card loading={loading}>
+            <Statistic
+              title="Forwards"
+              value={stats?.players?.forwards || 0}
+              prefix={<UserOutlined />}
+            />
+          </Card>
+        </Col>
+        <Col xs={12} sm={8} md={6} lg={4}>
+          <Card loading={loading}>
+            <Statistic
+              title="Defense"
+              value={stats?.players?.defense || 0}
+              prefix={<UserOutlined />}
+            />
+          </Card>
+        </Col>
+        <Col xs={12} sm={8} md={6} lg={4}>
+          <Card loading={loading}>
+            <Statistic
+              title="Goalies"
+              value={stats?.players?.goalies || 0}
+              prefix={<UserOutlined />}
+            />
+          </Card>
+        </Col>
+        <Col xs={12} sm={8} md={6} lg={4}>
+          <Card loading={loading}>
+            <Statistic
+              title="Forward Combos"
+              value={stats?.combos?.forward_combos || 0}
+              prefix={<TrophyOutlined />}
+            />
+          </Card>
+        </Col>
+        <Col xs={12} sm={8} md={6} lg={4}>
+          <Card loading={loading}>
+            <Statistic
+              title="Defense Combos"
+              value={stats?.combos?.defense_combos || 0}
+              prefix={<TrophyOutlined />}
+            />
+          </Card>
+        </Col>
+        <Col xs={12} sm={8} md={6} lg={4}>
+          <Card loading={loading}>
+            <Statistic
+              title="Teams"
+              value={stats?.teams?.length || 0}
+              prefix={<TeamOutlined />}
+            />
+          </Card>
+        </Col>
+      </Row>
+
+      {/* Quick Actions */}
+      <Card title="Quick Actions">
+        <Row gutter={[16, 16]}>
+          <Col xs={24} sm={12} md={8}>
+            <Link to="/players">
+              <Button type="primary" icon={<SearchOutlined />} block size="large">
+                Browse Players
+              </Button>
+            </Link>
+          </Col>
+          <Col xs={24} sm={12} md={8}>
+            <Link to="/optimize">
+              <Button type="default" icon={<RocketOutlined />} block size="large">
+                Optimize Lines
+              </Button>
+            </Link>
+          </Col>
+          <Col xs={24} sm={12} md={8}>
+            <Link to="/best">
+              <Button type="default" icon={<TrophyOutlined />} block size="large">
+                View Best Lines
+              </Button>
+            </Link>
+          </Col>
+        </Row>
+      </Card>
+
+      {/* Project Info */}
+      <Card title="About">
+        <Paragraph>
+          This project is part of the <strong>TKRR25 Knowledge Representation and Reasoning</strong> course 
+          final project at Jönköping University.
+        </Paragraph>
+        <Paragraph>
+          <strong>Key Technologies:</strong>
+        </Paragraph>
+        <Space wrap>
+          <span>Clingo (ASP)</span>
+          <span>•</span>
+          <span>FastAPI</span>
+          <span>•</span>
+          <span>React</span>
+          <span>•</span>
+          <span>Ant Design</span>
+          <span>•</span>
+          <span>SQLite</span>
+        </Space>
+      </Card>
+    </Flex>
+  );
+}
+
+export default HomePage;

--- a/frontend/src/pages/OptimizePage.tsx
+++ b/frontend/src/pages/OptimizePage.tsx
@@ -1,0 +1,270 @@
+/**
+ * OptimizePage - Line optimization form
+ */
+
+import { useState } from 'react';
+import {
+  Card,
+  Form,
+  Select,
+  InputNumber,
+  Button,
+  Space,
+  Flex,
+  Typography,
+  Row,
+  Col,
+  Divider,
+  Alert,
+  Spin,
+  Empty,
+} from 'antd';
+import { RocketOutlined, ReloadOutlined } from '@ant-design/icons';
+import { useApi, useLazyApi } from '../hooks/useApi';
+import { getTeams, getNationalities, getEvents } from '../api/players';
+import { optimizeForwardLine, optimizeDefensePair, getSolverStatus } from '../api/optimize';
+import { LineDisplay } from '../components/LineDisplay';
+import type { OptimizationRequest, OptimizationResponse } from '../api/types';
+
+const { Title, Paragraph } = Typography;
+
+type PositionType = 'forward' | 'defense';
+type OptimizationTarget = 'ovr' | 'salary' | 'ap' | 'balanced';
+
+interface FormValues {
+  position_type: PositionType;
+  optimization_target: OptimizationTarget;
+  min_ovr?: number;
+  max_salary?: number;
+  max_ap?: number;
+  required_team?: string;
+  required_nationality?: string;
+  required_event?: string;
+  num_solutions: number;
+}
+
+export function OptimizePage() {
+  const [form] = Form.useForm<FormValues>();
+  const [results, setResults] = useState<OptimizationResponse | null>(null);
+
+  // Fetch filter options
+  const { data: teams } = useApi(() => getTeams(), []);
+  const { data: nationalities } = useApi(() => getNationalities(), []);
+  const { data: events } = useApi(() => getEvents(), []);
+  const { data: solverStatus, loading: loadingStatus } = useApi(() => getSolverStatus(), []);
+
+  // Optimization mutation
+  const { loading: optimizing, error, execute: runOptimization } = useLazyApi(
+    async (values: FormValues) => {
+      const request: OptimizationRequest = {
+        constraints: {
+          min_ovr: values.min_ovr,
+          max_salary: values.max_salary,
+          max_ap: values.max_ap,
+          required_team: values.required_team,
+          required_nationality: values.required_nationality,
+          required_event: values.required_event,
+        },
+        optimization_target: values.optimization_target,
+        num_solutions: values.num_solutions,
+      };
+
+      if (values.position_type === 'forward') {
+        return optimizeForwardLine(request);
+      } else {
+        return optimizeDefensePair(request);
+      }
+    }
+  );
+
+  const handleSubmit = async (values: FormValues) => {
+    const result = await runOptimization(values);
+    if (result) {
+      setResults(result);
+    }
+  };
+
+  const handleReset = () => {
+    form.resetFields();
+    setResults(null);
+  };
+
+  return (
+    <Flex vertical gap="large" style={{ width: '100%' }}>
+      <Title level={2}>Optimize Lines</Title>
+
+      {/* Solver Status */}
+      {loadingStatus ? (
+        <Spin />
+      ) : solverStatus && !solverStatus.asp_ready ? (
+        <Alert
+          title="ASP Solver Not Ready"
+          description={solverStatus.message || 'The ASP solver is still being implemented. Results will use placeholder data.'}
+          type="warning"
+          showIcon
+        />
+      ) : null}
+
+      <Row gutter={24}>
+        {/* Form */}
+        <Col xs={24} lg={8}>
+          <Card title="Optimization Settings">
+            <Form
+              form={form}
+              layout="vertical"
+              onFinish={handleSubmit}
+              initialValues={{
+                position_type: 'forward',
+                optimization_target: 'ovr',
+                num_solutions: 5,
+              }}
+            >
+              <Form.Item
+                name="position_type"
+                label="Position Type"
+                rules={[{ required: true }]}
+              >
+                <Select
+                  options={[
+                    { label: 'Forward Line (3 players)', value: 'forward' },
+                    { label: 'Defense Pair (2 players)', value: 'defense' },
+                  ]}
+                />
+              </Form.Item>
+
+              <Form.Item
+                name="optimization_target"
+                label="Optimization Target"
+                rules={[{ required: true }]}
+              >
+                <Select
+                  options={[
+                    { label: 'Maximum OVR', value: 'ovr' },
+                    { label: 'Minimum Salary', value: 'salary' },
+                    { label: 'Minimum AP Cost', value: 'ap' },
+                    { label: 'Balanced', value: 'balanced' },
+                  ]}
+                />
+              </Form.Item>
+
+              <Divider>Constraints (Optional)</Divider>
+
+              <Form.Item name="min_ovr" label="Minimum OVR">
+                <InputNumber min={60} max={99} style={{ width: '100%' }} placeholder="e.g., 85" />
+              </Form.Item>
+
+              <Form.Item name="max_salary" label="Maximum Salary (K)">
+                <InputNumber min={0} style={{ width: '100%' }} placeholder="e.g., 300" />
+              </Form.Item>
+
+              <Form.Item name="max_ap" label="Maximum AP Cost">
+                <InputNumber min={0} style={{ width: '100%' }} placeholder="e.g., 10" />
+              </Form.Item>
+
+              <Form.Item name="required_team" label="Required Team">
+                <Select
+                  options={teams?.map((t) => ({ label: t, value: t })) || []}
+                  allowClear
+                  showSearch
+                  placeholder="Any team"
+                />
+              </Form.Item>
+
+              <Form.Item name="required_nationality" label="Required Nationality">
+                <Select
+                  options={nationalities?.map((n) => ({ label: n, value: n })) || []}
+                  allowClear
+                  showSearch
+                  placeholder="Any nationality"
+                />
+              </Form.Item>
+
+              <Form.Item name="required_event" label="Required Event">
+                <Select
+                  options={events?.map((e) => ({ label: e, value: e })) || []}
+                  allowClear
+                  showSearch
+                  placeholder="Any event"
+                />
+              </Form.Item>
+
+              <Divider>Results</Divider>
+
+              <Form.Item
+                name="num_solutions"
+                label="Number of Solutions"
+                rules={[{ required: true }]}
+              >
+                <InputNumber min={1} max={20} style={{ width: '100%' }} />
+              </Form.Item>
+
+              <Form.Item>
+                <Space style={{ width: '100%' }}>
+                  <Button
+                    type="primary"
+                    htmlType="submit"
+                    icon={<RocketOutlined />}
+                    loading={optimizing}
+                    block
+                  >
+                    Optimize
+                  </Button>
+                  <Button icon={<ReloadOutlined />} onClick={handleReset}>
+                    Reset
+                  </Button>
+                </Space>
+              </Form.Item>
+            </Form>
+          </Card>
+        </Col>
+
+        {/* Results */}
+        <Col xs={24} lg={16}>
+          <Card title="Results">
+            {error && (
+              <Alert title="Optimization Failed" description={error} type="error" showIcon />
+            )}
+
+            {optimizing && (
+              <div style={{ textAlign: 'center', padding: 40 }}>
+                <Spin size="large" />
+                <Paragraph style={{ marginTop: 16 }}>Running optimization...</Paragraph>
+              </div>
+            )}
+
+            {!optimizing && !results && !error && (
+              <Empty description="Configure settings and click Optimize to find the best lines" />
+            )}
+
+            {results && (
+              <Flex vertical gap="middle" style={{ width: '100%' }}>
+                {results.success ? (
+                  <>
+                    <Alert
+                      title={`Found ${results.solutions.length} solutions`}
+                      description={`Evaluated ${results.candidates_evaluated} candidates in ${results.computation_time_ms}ms`}
+                      type="success"
+                      showIcon
+                    />
+                    {results.solutions.map((solution, idx) => (
+                      <LineDisplay key={idx} line={solution} rank={solution.rank} />
+                    ))}
+                  </>
+                ) : (
+                  <Alert
+                    title="No solutions found"
+                    description={results.message}
+                    type="warning"
+                    showIcon
+                  />
+                )}
+              </Flex>
+            )}
+          </Card>
+        </Col>
+      </Row>
+    </Flex>
+  );
+}
+
+export default OptimizePage;

--- a/frontend/src/pages/PlayersPage.tsx
+++ b/frontend/src/pages/PlayersPage.tsx
@@ -1,0 +1,232 @@
+/**
+ * PlayersPage - Browse and search players
+ */
+
+import { useState, useMemo } from 'react';
+import {
+  Card,
+  Table,
+  Tabs,
+  Input,
+  Select,
+  Row,
+  Col,
+  Tag,
+  Space,
+  Flex,
+  Typography,
+  Alert,
+  Slider,
+} from 'antd';
+import { SearchOutlined } from '@ant-design/icons';
+import type { ColumnsType } from 'antd/es/table';
+import { useApi } from '../hooks/useApi';
+import { getForwards, getDefense, getGoalies, getTeams, getEvents } from '../api/players';
+import type { Player } from '../api/types';
+
+const { Title } = Typography;
+
+// Get color based on overall rating
+function getOvrColor(ovr: number): string {
+  if (ovr >= 90) return 'green';
+  if (ovr >= 85) return 'blue';
+  if (ovr >= 80) return 'purple';
+  if (ovr >= 75) return 'gold';
+  return 'default';
+}
+
+// Table columns definition
+const columns: ColumnsType<Player> = [
+  {
+    title: 'Name',
+    key: 'name',
+    render: (_, player) => `${player.first_name} ${player.last_name}`,
+    sorter: (a, b) => a.last_name.localeCompare(b.last_name),
+  },
+  {
+    title: 'OVR',
+    dataIndex: 'overall',
+    key: 'overall',
+    sorter: (a, b) => a.overall - b.overall,
+    defaultSortOrder: 'descend',
+    render: (ovr) => <Tag color={getOvrColor(ovr)}>{ovr}</Tag>,
+    width: 80,
+  },
+  {
+    title: 'Team',
+    dataIndex: 'team',
+    key: 'team',
+    width: 80,
+  },
+  {
+    title: 'Nationality',
+    dataIndex: 'nationality',
+    key: 'nationality',
+    width: 100,
+  },
+  {
+    title: 'Event',
+    dataIndex: 'event',
+    key: 'event',
+    render: (event) => event ? <Tag color="purple">{event}</Tag> : '-',
+    width: 120,
+  },
+  {
+    title: 'Salary',
+    dataIndex: 'salary',
+    key: 'salary',
+    sorter: (a, b) => a.salary - b.salary,
+    render: (salary) => `${salary}K`,
+    width: 80,
+  },
+];
+
+interface FiltersState {
+  search: string;
+  team?: string;
+  event?: string;
+  ovrRange: [number, number];
+}
+
+export function PlayersPage() {
+  const [activeTab, setActiveTab] = useState<'FWD' | 'DEF' | 'G'>('FWD');
+  const [filters, setFilters] = useState<FiltersState>({
+    search: '',
+    ovrRange: [60, 99],
+  });
+
+  // Fetch data
+  const { data: forwards, loading: loadingFwd, error: errorFwd } = useApi(() => getForwards(), []);
+  const { data: defense, loading: loadingDef, error: errorDef } = useApi(() => getDefense(), []);
+  const { data: goalies, loading: loadingG, error: errorG } = useApi(() => getGoalies(), []);
+  const { data: teams } = useApi(() => getTeams(), []);
+  const { data: events } = useApi(() => getEvents(), []);
+
+  // Get current players based on tab
+  const currentPlayers = useMemo(() => {
+    switch (activeTab) {
+      case 'FWD': return forwards || [];
+      case 'DEF': return defense || [];
+      case 'G': return goalies || [];
+    }
+  }, [activeTab, forwards, defense, goalies]);
+
+  const isLoading = activeTab === 'FWD' ? loadingFwd : activeTab === 'DEF' ? loadingDef : loadingG;
+  const error = activeTab === 'FWD' ? errorFwd : activeTab === 'DEF' ? errorDef : errorG;
+
+  // Filter players
+  const filteredPlayers = useMemo(() => {
+    return currentPlayers.filter((player) => {
+      // Search filter
+      if (filters.search) {
+        const searchLower = filters.search.toLowerCase();
+        const fullName = `${player.first_name} ${player.last_name}`.toLowerCase();
+        if (!fullName.includes(searchLower)) {
+          return false;
+        }
+      }
+      // Team filter
+      if (filters.team && player.team !== filters.team) {
+        return false;
+      }
+      // Event filter
+      if (filters.event && player.event !== filters.event) {
+        return false;
+      }
+      // OVR range filter
+      if (player.overall < filters.ovrRange[0] || player.overall > filters.ovrRange[1]) {
+        return false;
+      }
+      return true;
+    });
+  }, [currentPlayers, filters]);
+
+  return (
+    <Flex vertical gap="large" style={{ width: '100%' }}>
+      <Title level={2}>Players</Title>
+
+      {error && (
+        <Alert title="Failed to load players" description={error} type="error" showIcon />
+      )}
+
+      {/* Filters */}
+      <Card size="small">
+        <Row gutter={[16, 16]} align="middle">
+          <Col xs={24} sm={12} md={6}>
+            <Input
+              prefix={<SearchOutlined />}
+              placeholder="Search by name..."
+              value={filters.search}
+              onChange={(e) => setFilters({ ...filters, search: e.target.value })}
+              allowClear
+            />
+          </Col>
+          <Col xs={24} sm={12} md={4}>
+            <Select
+              placeholder="Team"
+              value={filters.team}
+              onChange={(value) => setFilters({ ...filters, team: value })}
+              options={teams?.map((t) => ({ label: t, value: t })) || []}
+              allowClear
+              style={{ width: '100%' }}
+              showSearch
+            />
+          </Col>
+          <Col xs={24} sm={12} md={4}>
+            <Select
+              placeholder="Event"
+              value={filters.event}
+              onChange={(value) => setFilters({ ...filters, event: value })}
+              options={events?.map((e) => ({ label: e, value: e })) || []}
+              allowClear
+              style={{ width: '100%' }}
+              showSearch
+            />
+          </Col>
+          <Col xs={24} sm={12} md={6}>
+            <Space style={{ width: '100%' }}>
+              <span>OVR:</span>
+              <Slider
+                range
+                min={60}
+                max={99}
+                value={filters.ovrRange}
+                onChange={(value) => setFilters({ ...filters, ovrRange: value as [number, number] })}
+                style={{ flex: 1, minWidth: 120 }}
+              />
+              <span>{filters.ovrRange[0]}-{filters.ovrRange[1]}</span>
+            </Space>
+          </Col>
+        </Row>
+      </Card>
+
+      {/* Players Table with Tabs */}
+      <Card>
+        <Tabs
+          activeKey={activeTab}
+          onChange={(key) => setActiveTab(key as 'FWD' | 'DEF' | 'G')}
+          items={[
+            { key: 'FWD', label: `Forwards (${forwards?.length || 0})` },
+            { key: 'DEF', label: `Defense (${defense?.length || 0})` },
+            { key: 'G', label: `Goalies (${goalies?.length || 0})` },
+          ]}
+        />
+        <Table
+          columns={columns}
+          dataSource={filteredPlayers}
+          rowKey="id"
+          loading={isLoading}
+          pagination={{
+            pageSize: 20,
+            showSizeChanger: true,
+            showTotal: (total) => `${total} players`,
+          }}
+          size="small"
+          scroll={{ x: 800 }}
+        />
+      </Card>
+    </Flex>
+  );
+}
+
+export default PlayersPage;

--- a/frontend/src/pages/index.ts
+++ b/frontend/src/pages/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Page exports
+ */
+
+export { HomePage } from './HomePage';
+export { PlayersPage } from './PlayersPage';
+export { OptimizePage } from './OptimizePage';
+export { BestLinesPage } from './BestLinesPage';

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'http://localhost:8000',
+        target: 'http://127.0.0.1:8000',
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, ''),
       },


### PR DESCRIPTION
### Summary
- Add complete React frontend with API integration, reusable components, and page routing
- Implement data fetching hooks and typed API client for all backend endpoints
- Configure Vite proxy for seamless backend communication during development

### Changes

**API Layer** (`frontend/src/api/`)
- `client.ts` - Generic fetch wrapper with error handling
- `types.ts` - TypeScript interfaces for all API data models
- `players.ts` - Player search, filters, and stats endpoints
- `combos.ts` - Line combination endpoints
- `optimize.ts` - Optimization run endpoints
- `best.ts` - Goal 1 pre-computed results endpoints

**Components** (`frontend/src/components/`)
- `PlayerCard` - Display player info with stats
- `LineDisplay` - Show line of players with active combos
- `ComboCard` - Display line combination details
- `PlayerSearch` - Autocomplete player search

**Pages** (`frontend/src/pages/`)
- `HomePage` - Dashboard with dataset statistics
- `PlayersPage` - Browse/search players with filters
- `OptimizePage` - Configure and run optimizations
- `BestLinesPage` - View Goal 1 pre-computed results

**Hooks** (`frontend/src/hooks/`)
- `useApi` - Auto-fetch on mount with loading/error states
- `useLazyApi` - Manual trigger fetch hook

**Config**
- Updated `vite.config.ts` with `/api` proxy to backend
- Updated `.gitignore` with additional frontend patterns
- Updated `FRONTEND_INTEGRATION.md` with correct API types

### Test Plan
- [ ] Follow README.md to install frontend requirements, start backend and frontend
- [ ] Verify Home page loads statistics
- [ ] Verify Players page filters work
- [ ] Verify navigation between pages